### PR TITLE
Missing Android Dependencies

### DIFF
--- a/nuspec/Birdie.MvvmCross.Plugins.UserInteraction.nuspec
+++ b/nuspec/Birdie.MvvmCross.Plugins.UserInteraction.nuspec
@@ -11,7 +11,14 @@
 		<description>This package contains a 'UserInteraction' plugin for MvvmCross v4</description>
 		<tags>mvvm mvvmcross xamarin monodroid monotouch wp wpdev windowsphone uwp</tags>
 		<dependencies>
-		  <dependency id="MvvmCross.Platform" version="4.0.0" />
+		  <group>
+		    <dependency id="MvvmCross.Platform" version="4.0.0" />	
+		  </group>
+		  <group targetFramework="monoandroid">
+		    <dependency id="MvvmCross.Platform" version="4.0.0" />
+		    <dependency id="Xamarin.Android.Support.v4" />
+		    <dependency id="Xamarin.Android.Support.v7.AppCompat" />
+		  </group>
 		</dependencies>
 	</metadata>
 	<files>		


### PR DESCRIPTION
Xamarin.Android.Support.v4 and Xamarin.Android.Support.v7.AppCompat were missing from the nuspec and are required for Xamarin Android projects.
